### PR TITLE
Fix deletion on large tables

### DIFF
--- a/src/Store/DynamoDbStore.php
+++ b/src/Store/DynamoDbStore.php
@@ -10,7 +10,7 @@ use CredStash\Exception\CredentialNotFoundException;
 
 /**
  * A DynamoDB credential store.
- * 
+ *
  * @author Carson Full <carsonfull@gmail.com>
  */
 class DynamoDbStore implements StoreInterface
@@ -140,7 +140,7 @@ class DynamoDbStore implements StoreInterface
      */
     public function delete($name)
     {
-        $response = $this->db->scan([
+        $pages = $this->db->getPaginator('Scan', [
             'TableName'                 => $this->tableName,
             'FilterExpression'          => '#N = :name',
             'ProjectionExpression'      => '#N, version',
@@ -152,17 +152,19 @@ class DynamoDbStore implements StoreInterface
             ],
         ]);
 
-        foreach ($response['Items'] as $item) {
-            $this->db->deleteItem([
-                'TableName' => $this->tableName,
-                'Key' => $item,
-            ]);
+        foreach ($pages as $page) {
+            foreach ($page['Items'] as $item) {
+                $this->db->deleteItem([
+                    'TableName' => $this->tableName,
+                    'Key' => $item,
+                ]);
+            }
         }
     }
 
     /**
      * Queries the DB for the secret.
-     * 
+     *
      * @param string     $name
      * @param string|null $projection Optional projection expression
      *


### PR DESCRIPTION
The maximum number of items to evaluate (not necessarily the number of matching items). If DynamoDB processes the number of items up to the limit while processing the results, it stops the operation and returns the matching values up to that point, and a key in LastEvaluatedKey to apply in a subsequent operation, so that you can pick up where you left off. Also, if the processed dataset size exceeds 1 MB before DynamoDB reaches this limit, it stops the operation and returns the matching values up to the limit, and a key in LastEvaluatedKey to apply in a subsequent operation to continue the operation

Refer to https://github.com/fugue/credstash/pull/240/commits/c343a875fdf84d49483692c7552b7b0fc17f3768